### PR TITLE
Add admin settings page and improve security

### DIFF
--- a/js/assistant.js
+++ b/js/assistant.js
@@ -1,2 +1,16 @@
-// Admin JS for OpenAI Assistant v2.9.19
-jQuery(()=>console.log('OA Admin loaded v2.9.19'));
+// Admin JS for OpenAI Assistant v2.9.20
+jQuery(function($){
+  console.log('OA Admin loaded v2.9.20');
+  $('#oa-add-config').on('click', function(){
+    var table = $('#oa-configs tbody');
+    var idx = table.find('tr').length;
+    var row = '<tr>'+
+      '<td><input name="oa_assistant_configs['+idx+'][nombre]" /></td>'+
+      '<td><input name="oa_assistant_configs['+idx+'][slug]" /></td>'+
+      '<td><input name="oa_assistant_configs['+idx+'][assistant_id]" /></td>'+
+      '<td><textarea name="oa_assistant_configs['+idx+'][developer_instructions]"></textarea></td>'+
+      '<td><input name="oa_assistant_configs['+idx+'][vector_store_id]" /></td>'+
+    '</tr>';
+    table.append(row);
+  });
+});


### PR DESCRIPTION
## Summary
- support encrypted API key storage
- add admin page to manage plugin settings
- update JavaScript to add assistant rows dynamically
- implement simple vector store retrieval using posts
- improve error handling for OpenAI requests

## Testing
- `php -l openai-assistant.php`
- `node --check js/assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_6880ca5a2124833287d0dbb350fd5a52